### PR TITLE
Fixes error when running `pod install`

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,9 +3,4 @@ use_frameworks!
 target 'MapViewPlus_Example' do
   pod 'MapViewPlus', :path => '../'
 
-  target 'MapViewPlus_Tests' do
-    inherit! :search_paths
-
-    
-  end
 end


### PR DESCRIPTION
Fixes `pod install` error : `"Unable to find a target named MapViewPlus_Tests, did find MapViewPlus_Example."`